### PR TITLE
Fix broken setup chatterbot link

### DIFF
--- a/Wiki/Setup-Misc.md
+++ b/Wiki/Setup-Misc.md
@@ -1,7 +1,7 @@
 Here you'll find supplementary information that can be used to enhance TRBot! 
 
 # Chatbot
-See the [chatbot guide](./Setup-ChatterBot.md) for setting up a chatbot that your viewers can talk to!
+See the [chatbot guide](./Setup-Chatterbot.md) for setting up a chatbot that your viewers can talk to!
 
 # Game Message
 TRBot has an optional game message that can be set with the `SetMessageCommand`. An example of such a message may be "Beat level 1". Once set, the message is saved into a file specified by the **game_message_path** setting in the database (the default is a **GameMessage.txt** file in the **Data** folder). You can display this message on screen using OBS via the following steps:


### PR DESCRIPTION
Hello,

I noticed that the link to Setup-Chatterbot.md was giving me a 404 error on GitHub because it was capitalised as `Setup-Chatterbot.md`. This commit fixes the capitalisation and fixes the link :)

Cheers
Caitlin